### PR TITLE
UPGRADE: attrs -> v21

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    attrs>=19,<21
+    attrs>=19
 python_requires = ~=3.6
 include_package_data = True
 zip_safe = False


### PR DESCRIPTION
Removing restriction for `attrs <21`. Only major breaking change is that `evolve` changed to not be recursive, but `evolve` is not used.